### PR TITLE
Add transit-format to benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+.idea
 pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,12 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>com.cognitect</groupId>
+            <artifactId>transit-java</artifactId>
+            <version>0.8.287</version>
+        </dependency>
+
         <!-- JMH benchmark -->
         <dependency>
             <groupId>org.openjdk.jmh</groupId>

--- a/src/main/java/no/finntech/shootout/Case.java
+++ b/src/main/java/no/finntech/shootout/Case.java
@@ -21,10 +21,13 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.BenchmarkParams;
 
 /**
@@ -92,6 +95,8 @@ public abstract class Case<T> {
 
     @Benchmark
     @Fork(0)
+    @BenchmarkMode(Mode.SingleShotTime)
+    @Warmup(iterations = 1)
     public void sizer(BenchmarkParams params) {
         saveSize(params.getBenchmark(), getSize());
     }

--- a/src/main/java/no/finntech/shootout/transit/Application.java
+++ b/src/main/java/no/finntech/shootout/transit/Application.java
@@ -1,0 +1,42 @@
+package no.finntech.shootout.transit;
+
+import java.util.Map;
+
+import com.cognitect.transit.ReadHandler;
+import com.cognitect.transit.impl.AbstractWriteHandler;
+
+import static no.finntech.shootout.transit.Writers.map;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public final class Application {
+    private final String id;
+
+    public Application(String id) {
+        this.id = checkNotNull(id);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    static final class AppWriter extends AbstractWriteHandler<Application, Object> {
+        @Override
+        public String tag(Application o) {
+            return "application";
+        }
+
+        @Override
+        public Object rep(Application o) {
+            return map("id", o.getId());
+        }
+
+    }
+
+    static final class AppReader implements ReadHandler<Object, Map<String, String>> {
+
+        @Override
+        public Object fromRep(Map<String, String> map) {
+            return new Application(map.get("id"));
+        }
+    }
+}

--- a/src/main/java/no/finntech/shootout/transit/Base.java
+++ b/src/main/java/no/finntech/shootout/transit/Base.java
@@ -1,0 +1,99 @@
+package no.finntech.shootout.transit;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.time.Instant;
+import java.util.Map;
+import java.util.OptionalInt;
+
+import no.finntech.shootout.Case;
+import no.finntech.shootout.Constants;
+import no.finntech.shootout.Constants.Ad;
+import no.finntech.shootout.Constants.AttributedTo;
+import no.finntech.shootout.Constants.AvailableAt;
+import no.finntech.shootout.Constants.Seller;
+import no.finntech.shootout.Constants.Viewer;
+
+import com.cognitect.transit.ReadHandler;
+import com.cognitect.transit.TransitFactory;
+import com.cognitect.transit.WriteHandler;
+import com.cognitect.transit.impl.AbstractWriteHandler;
+import com.google.common.collect.ImmutableMap;
+import org.openjdk.jmh.annotations.Benchmark;
+
+import static java.util.Optional.of;
+import static no.finntech.shootout.transit.Writers.map;
+
+public abstract class Base extends Case<TransitView> {
+    private static final String INSTANT = "instant";
+    private static final Map<Class, WriteHandler<?, ?>> WRITERS = ImmutableMap.<Class, WriteHandler<?, ?>>builder()
+            .put(Application.class, new Application.AppWriter())
+            .put(Offer.class, new Offer.OfferWriter())
+            .put(Person.class, new Person.PersonWriter())
+            .put(Place.class, new Place.PlaceWriter())
+            .put(TransitView.class, new TransitView.TVWriter())
+            .put(Instant.class, new InstantWriter())
+            .build();
+    private static final Map<String, ReadHandler<?, ?>> READERS = ImmutableMap.<String, ReadHandler<?, ?>>builder()
+            .put("application", new Application.AppReader())
+            .put("offer", new Offer.OfferReader())
+            .put("person", new Person.PersonReader())
+            .put("place", new Place.PlaceReader())
+            .put("case", new TransitView.TVReader())
+            .put(INSTANT, new InstantReader())
+            .build();
+    private static final TransitView VIEW = new TransitView(
+            Instant.parse(Constants.PUBLISHED),
+            new Person(Viewer.ID, of(Viewer.UNIQUE_ID), of(Viewer.SESSION_ID), of(Viewer.USER_AGENT), of(Viewer.CLIENT_DEVICE),
+                    of(Viewer.REMOTE_ADDR)),
+            new Offer(Ad.ID, of(Ad.NAME), of(Ad.CATEGORY), of(new Person(Seller.ID)), of(new Place(AvailableAt.ID)),
+                    OptionalInt.of(Ad.PRICE)),
+            of(new Application(Constants.Generator.ID)),
+            of(TransitFactory.link(AttributedTo.HREF, AttributedTo.REL)));
+
+    private final TransitFactory.Format format;
+
+    protected Base(TransitFactory.Format format) {
+        this.format = format;
+    }
+
+    @Override
+    protected TransitView buildObject() {
+        return VIEW;
+    }
+
+    @Override
+    @Benchmark
+    public ByteArrayOutputStream write() throws Exception {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        TransitFactory.writer(format, out, WRITERS).write(getObject());
+        return out;
+    }
+
+    @Override
+    @Benchmark
+    public TransitView read() throws Exception {
+        return TransitFactory.reader(format, new ByteArrayInputStream(getBytes()), READERS).read();
+    }
+
+    static final class InstantWriter extends AbstractWriteHandler<Instant, Object> {
+
+        @Override
+        public String tag(Instant o) {
+            return INSTANT;
+        }
+
+        @Override
+        public Object rep(Instant o) {
+            return map("s", o.getEpochSecond(), "n", o.getNano());
+        }
+    }
+
+    static final class InstantReader implements ReadHandler<Object, Map<String, Long>> {
+
+        @Override
+        public Object fromRep(Map<String, Long> m) {
+            return Instant.ofEpochSecond(m.get("s"), m.get("n").intValue());
+        }
+    }
+}

--- a/src/main/java/no/finntech/shootout/transit/BinaryTransit.java
+++ b/src/main/java/no/finntech/shootout/transit/BinaryTransit.java
@@ -1,0 +1,9 @@
+package no.finntech.shootout.transit;
+
+import com.cognitect.transit.TransitFactory;
+
+public class BinaryTransit extends Base {
+    public BinaryTransit() {
+        super(TransitFactory.Format.MSGPACK);
+    }
+}

--- a/src/main/java/no/finntech/shootout/transit/JsonTransit.java
+++ b/src/main/java/no/finntech/shootout/transit/JsonTransit.java
@@ -1,0 +1,17 @@
+package no.finntech.shootout.transit;
+
+import com.cognitect.transit.TransitFactory;
+
+public class JsonTransit extends Base {
+    public JsonTransit() {
+        super(TransitFactory.Format.JSON);
+    }
+
+    public static void main(String[] args) throws Exception {
+        final Base transit = new JsonTransit();
+        transit.prepare();
+        System.out.println(transit.write().toString("UTF-8"));
+        final TransitView read = transit.read();
+        System.out.println(read);
+    }
+}

--- a/src/main/java/no/finntech/shootout/transit/Offer.java
+++ b/src/main/java/no/finntech/shootout/transit/Offer.java
@@ -1,0 +1,74 @@
+package no.finntech.shootout.transit;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import com.cognitect.transit.ReadHandler;
+import com.cognitect.transit.impl.AbstractWriteHandler;
+import com.google.common.collect.Maps;
+
+import static java.util.Optional.ofNullable;
+
+public final class Offer {
+    private final String id;
+    private final Optional<String> name;
+    private final Optional<String> category;
+    private final Optional<Person> seller;
+    private final Optional<Place> availableAt;
+    private final OptionalInt price;
+
+    public Offer(String id, Optional<String> name, Optional<String> category, Optional<Person> seller, Optional<Place> availableAt,
+                 OptionalInt price) {
+        this.id = id;
+        this.name = name;
+        this.category = category;
+        this.seller = seller;
+        this.availableAt = availableAt;
+        this.price = price;
+    }
+
+
+    static final class OfferWriter extends AbstractWriteHandler<Offer, Object> {
+
+        @Override
+        public String tag(Offer Offer) {
+            return "offer";
+        }
+
+        @Override
+        public Object rep(Offer o) {
+            final HashMap<String, Object> m = Maps.newHashMapWithExpectedSize(6);
+            m.put("id", o.id);
+            o.name.ifPresent(n -> m.put("name", n));
+            o.category.ifPresent(c -> m.put("category", c));
+            o.seller.ifPresent(s -> m.put("seller", s));
+            o.availableAt.ifPresent(aa -> m.put("availableAt", aa));
+            o.price.ifPresent(p -> m.put("price", p));
+            return m;
+        }
+    }
+
+    static final class OfferReader implements ReadHandler<Object, Map<String, Object>> {
+
+        @Override
+        public Object fromRep(Map<String, Object> m) {
+            return new Offer(
+                    required(m, "id", String.class),
+                    optional(m, "name", String.class),
+                    optional(m, "category", String.class),
+                    optional(m, "seller", Person.class),
+                    optional(m, "availableAt", Place.class),
+                    optional(m, "price", Long.class).map(l -> OptionalInt.of(l.intValue())).orElse(OptionalInt.empty()));
+        }
+
+        private static <T> Optional<T> optional(Map<String, Object> m, String key, Class<T> aClass) {
+            return ofNullable(m.get(key)).map(aClass::cast);
+        }
+
+        private static <T> T required(Map<String, Object> m, String key, Class<T> aClass) {
+            return optional(m, key, aClass).orElseThrow(() -> new IllegalArgumentException("Missing key: " + key));
+        }
+    }
+}

--- a/src/main/java/no/finntech/shootout/transit/Person.java
+++ b/src/main/java/no/finntech/shootout/transit/Person.java
@@ -1,0 +1,106 @@
+package no.finntech.shootout.transit;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import com.cognitect.transit.ReadHandler;
+import com.cognitect.transit.impl.AbstractWriteHandler;
+
+import static java.util.Optional.empty;
+import static java.util.Optional.ofNullable;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public final class Person {
+    private static final String ID = "id";
+    private static final String UNIQUE_VISITOR_ID = "uniqueVisitorId";
+    private static final String SESSION_ID = "sessionId";
+    private static final String USER_AGENT = "userAgent";
+    private static final String CLIENT_DEVICE = "clientDevice";
+    private static final String REMOTE_ADDR = "remoteAddr";
+
+    private final String id;
+    private final Optional<String> uniqueVisitorId;
+    private final Optional<String> sessionId;
+    private final Optional<String> userAgent;
+    private final Optional<String> clientDevice;
+    private final Optional<String> remoteAddress;
+
+    public Person(String id) {
+        this(id, empty(), empty(), empty(), empty(), empty());
+    }
+
+    public Person(String id, Optional<String> uniqueVisitorId, Optional<String> sessionId, Optional<String> userAgent,
+                  Optional<String> clientDevice, Optional<String> remoteAddress) {
+        this.id = checkNotNull(id);
+        this.uniqueVisitorId = uniqueVisitorId;
+        this.sessionId = sessionId;
+        this.userAgent = userAgent;
+        this.clientDevice = clientDevice;
+        this.remoteAddress = remoteAddress;
+    }
+
+
+    public String getId() {
+        return id;
+    }
+
+    public Optional<String> getUniqueVisitorId() {
+        return uniqueVisitorId;
+    }
+
+    public Optional<String> getSessionId() {
+        return sessionId;
+    }
+
+    public Optional<String> getUserAgent() {
+        return userAgent;
+    }
+
+    public Optional<String> getClientDevice() {
+        return clientDevice;
+    }
+
+    public Optional<String> getRemoteAddr() {
+        return remoteAddress;
+    }
+
+    static final class PersonWriter extends AbstractWriteHandler<Person, Object> {
+
+        @Override
+        public String tag(Person p) {
+            return "person";
+        }
+
+        @Override
+        public Object rep(Person p) {
+            final HashMap<String, String> m = new HashMap<>(8);
+            m.put(ID, p.getId());
+            putIfPresent(m, p.getUniqueVisitorId(), UNIQUE_VISITOR_ID);
+            putIfPresent(m, p.getSessionId(), SESSION_ID);
+            putIfPresent(m, p.getUserAgent(), USER_AGENT);
+            putIfPresent(m, p.getClientDevice(), CLIENT_DEVICE);
+            putIfPresent(m, p.getRemoteAddr(), REMOTE_ADDR);
+            return m;
+        }
+
+        private void putIfPresent(final HashMap<String, String> m, Optional<String> opt, String key) {
+            opt.ifPresent(i -> m.put(key, i));
+        }
+    }
+
+    static final class PersonReader implements ReadHandler<Object, Map<String, String>> {
+
+        @Override
+        public Object fromRep(Map<String, String> map) {
+            return new Person(
+                    map.get(ID),
+                    ofNullable(map.get(UNIQUE_VISITOR_ID)),
+                    ofNullable(map.get(SESSION_ID)),
+                    ofNullable(map.get(USER_AGENT)),
+                    ofNullable(map.get(CLIENT_DEVICE)),
+                    ofNullable(map.get(REMOTE_ADDR))
+            );
+        }
+    }
+}

--- a/src/main/java/no/finntech/shootout/transit/Place.java
+++ b/src/main/java/no/finntech/shootout/transit/Place.java
@@ -1,0 +1,41 @@
+package no.finntech.shootout.transit;
+
+import java.util.Map;
+
+import com.cognitect.transit.ReadHandler;
+import com.cognitect.transit.impl.AbstractWriteHandler;
+
+import static no.finntech.shootout.transit.Writers.map;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public final class Place {
+    private final String id;
+
+    public Place(String id) {
+        this.id = checkNotNull(id);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    static final class PlaceWriter extends AbstractWriteHandler<Place, Object> {
+        @Override
+        public String tag(Place o) {
+            return "place";
+        }
+
+        @Override
+        public Object rep(Place o) {
+            return map("id", o.getId());
+        }
+    }
+
+    static final class PlaceReader implements ReadHandler<Object, Map<String, String>> {
+
+        @Override
+        public Object fromRep(Map<String, String> map) {
+            return new Place(map.get("id"));
+        }
+    }
+}

--- a/src/main/java/no/finntech/shootout/transit/TransitView.java
+++ b/src/main/java/no/finntech/shootout/transit/TransitView.java
@@ -1,0 +1,95 @@
+package no.finntech.shootout.transit;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import com.cognitect.transit.Link;
+import com.cognitect.transit.ReadHandler;
+import com.cognitect.transit.impl.AbstractWriteHandler;
+
+import static java.util.Optional.ofNullable;
+
+public final class TransitView {
+    private static final String PUBLISHED = "published";
+    private static final String ACTOR = "actor";
+    private static final String OFFER = "offer";
+    private static final String GENERATOR = "generator";
+    private static final String ATTRIBUTED_TO = "attributedTo";
+
+    private final Instant published;
+    private final Person actor;
+    private final Offer offer;
+    private final Optional<Application> generator;
+    private final Optional<Link> attributedTo;
+
+    public TransitView(Instant published, Person actor, Offer offer, Optional<Application> generator, Optional<Link> attributedTo) {
+        this.actor = actor;
+        this.published = published;
+        this.offer = offer;
+        this.generator = generator;
+        this.attributedTo = attributedTo;
+    }
+
+    public Instant getPublished() {
+        return published;
+    }
+
+    public Person getActor() {
+        return actor;
+    }
+
+    public Offer getOffer() {
+        return offer;
+    }
+
+    public Optional<Application> getGenerator() {
+        return generator;
+    }
+
+    public Optional<Link> getAttributedTo() {
+        return attributedTo;
+    }
+
+    static final class TVWriter extends AbstractWriteHandler<TransitView, Object> {
+
+        @Override
+        public String tag(TransitView transitView) {
+            return "case";
+        }
+
+        @Override
+        public Object rep(TransitView tv) {
+            final HashMap<Object, Object> m = Writers.map(
+                    PUBLISHED, tv.getPublished(),
+                    ACTOR, tv.getActor(),
+                    OFFER, tv.getOffer()
+            );
+            tv.getGenerator().ifPresent(g -> m.put(GENERATOR, g));
+            tv.getAttributedTo().ifPresent(a -> m.put(ATTRIBUTED_TO, a));
+            return m;
+        }
+    }
+
+    static final class TVReader implements ReadHandler<Object, Map<String, Object>> {
+
+        @Override
+        public Object fromRep(Map<String, Object> m) {
+            return new TransitView(
+                    required(m, PUBLISHED, Instant.class),
+                    required(m, ACTOR, Person.class),
+                    required(m, OFFER, Offer.class),
+                    optional(m, GENERATOR, Application.class),
+                    optional(m, ATTRIBUTED_TO, Link.class));
+        }
+
+        private static <T> Optional<T> optional(Map<String, Object> m, String key, Class<T> aClass) {
+            return ofNullable(m.get(key)).map(aClass::cast);
+        }
+
+        private static <T> T required(Map<String, Object> m, String key, Class<T> aClass) {
+            return optional(m, key, aClass).orElseThrow(() -> new IllegalArgumentException("Missing " + key));
+        }
+    }
+}

--- a/src/main/java/no/finntech/shootout/transit/Writers.java
+++ b/src/main/java/no/finntech/shootout/transit/Writers.java
@@ -1,0 +1,26 @@
+package no.finntech.shootout.transit;
+
+import java.util.HashMap;
+
+public final class Writers {
+    public static HashMap<Object, Object> map(Object k, Object v) {
+        final HashMap<Object, Object> m = new HashMap<>(2);
+        m.put(k, v);
+        return m;
+    }
+
+    public static HashMap<Object, Object> map(Object k1, Object v1, Object k2, Object v2) {
+        final HashMap<Object, Object> m = new HashMap<>(4);
+        m.put(k1, v1);
+        m.put(k2, v2);
+        return m;
+    }
+
+    public static HashMap<Object, Object> map(Object k1, Object v1, Object k2, Object v2, Object k3, Object v3) {
+        final HashMap<Object, Object> m = new HashMap<>(8);
+        m.put(k1, v1);
+        m.put(k2, v2);
+        m.put(k3, v3);
+        return m;
+    }
+}


### PR DESCRIPTION
Transit is absolutely missing from this comparison. Added :)

I haven't had the time to run all the tests, but compared to BinaryAvro it seems to be interesting at least.
